### PR TITLE
Fix unintended relation to users when a model uses HasPermissions trait

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -108,7 +108,7 @@ class Permission extends Model implements PermissionInterface
      * A permission belongs to some users of the model associated with its guard.
      * @return BelongsToMany
      */
-    public function users()
+    public function users(): BelongsToMany
     {
         return $this->belongsToMany($this->helpers->getModelForGuard($this->attributes['guard_name']));
     }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -3,6 +3,7 @@
 namespace Maklad\Permission\Models;
 
 use Jenssegers\Mongodb\Eloquent\Model;
+use Jenssegers\Mongodb\Relations\BelongsToMany;
 use Maklad\Permission\Contracts\RoleInterface;
 use Maklad\Permission\Exceptions\GuardDoesNotMatch;
 use Maklad\Permission\Exceptions\RoleAlreadyExists;
@@ -115,6 +116,15 @@ class Role extends Model implements RoleInterface
         }
 
         return $role;
+    }
+
+    /**
+     * A role belongs to some users of the model associated with its guard.
+     * @return BelongsToMany
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany($this->helpers->getModelForGuard($this->attributes['guard_name']));
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -50,14 +50,6 @@ trait HasPermissions
     }
 
     /**
-     * A role belongs to some users of the model associated with its guard.
-     */
-    public function users(): BelongsToMany
-    {
-        return $this->belongsToMany($this->helpers->getModelForGuard($this->attributes['guard_name']));
-    }
-
-    /**
      * Grant the given permission(s) to a role.
      *
      * @param string|array|Permission|\Illuminate\Support\Collection $permissions

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -430,4 +430,10 @@ class HasPermissionsTest extends TestCase
         $this->testUser->assignRole('testRole');
         $this->assertTrue($this->testUser->hasAllPermissions('edit-articles', 'edit-news'));
     }
+
+    /** @test */
+    public function a_model_that_uses_hasPermissions_trait_should_not_have_users_method()
+    {
+        $this->assertFalse(method_exists($this->testUser, 'users'));
+    }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -347,4 +347,10 @@ class HasRolesTest extends TestCase
 
         $this->assertFalse($this->testUser->hasRole('testRole2'));
     }
+
+    /** @test */
+    public function a_model_that_uses_hasRoles_trait_should_not_have_users_method()
+    {
+        $this->assertFalse(method_exists($this->testUser, 'users'));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moved `users` method from HasPermissions trait to Role model. The list of users related to Role or Permission are still accessible from the respective models. For example, `$role->users` and `$permission->users`

## Motivation and context

Models that use HasPermissions trait should not unintentionally be related to User model. fixes #94 

## How has this been tested?

Added additional tests to assert that a model that uses HasRoles or HasPermissions trait does not have `users` method
```
/** @test */
public function a_model_that_uses_hasPermissions_trait_should_not_have_users_method()
{
    $this->assertFalse(method_exists($this->testUser, 'users'));
}
```

```
/** @test */
public function a_model_that_uses_hasRoles_trait_should_not_have_users_method()
{
    $this->assertFalse(method_exists($this->testUser, 'users'));
}
```

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
