### PR TITLE
Fix: When the permission is revoked from the role, the array changes to an object.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "mostafamaklad/laravel-permission-mongodb",
     "description": "Permission handling for Laravel 5.2 and up using mongodb",
-    "version": "dev-master",
     "keywords": [
         "laravel",
         "security",

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -98,11 +98,13 @@ trait HasPermissions
     {
         $permissions = $this->getPermissionIds($permissions);
 
-        $this->permission_ids = collect($this->permission_ids ?? [])
-            ->filter(function ($permission) use ($permissions) {
-                return ! in_array($permission, $permissions, true);
-            })
-            ->all();
+        $this->permission_ids = array_values(
+            collect($this->permission_ids ?? [])
+                ->filter(function ($permission) use ($permissions) {
+                    return !in_array($permission, $permissions, true);
+                })
+                ->all()
+        );
 
         $this->save();
 

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -200,6 +200,21 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    public function it_reindexes_permission_ids_when_revoking_a_middle_permission()
+    {
+        $this->testUserRole->givePermissionTo('edit-articles', 'edit-news', 'edit-categories');
+
+        $this->testUserRole->revokePermissionTo('edit-news');
+
+        $this->testUserRole = $this->testUserRole->fresh();
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('edit-articles'));
+        $this->assertFalse($this->testUserRole->hasPermissionTo('edit-news'));
+        $this->assertTrue($this->testUserRole->hasPermissionTo('edit-categories'));
+        $this->assertSame([0, 1], array_keys($this->testUserRole->permission_ids));
+    }
+
+    /** @test */
     public function it_can_be_given_a_permission_using_objects()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);


### PR DESCRIPTION
## Description

Fixes an issue where revoking a permission from a role could cause the `permissions` array to be converted into an object when the removed permission was not the last element in the array.

The array is now properly re-indexed after removing the permission, ensuring the structure remains a valid array.

## Motivation and context

When a permission was revoked from a role, MongoDB could store the resulting array as an object if the removed permission was in the middle of the array indexes. This caused inconsistent data structures and unexpected behavior when retrieving permissions.

This change ensures the array indexes are reset correctly after removing a permission.

## How has this been tested?

Tested by:

* Creating a role with multiple permissions
* Revoking a permission from the middle of the permissions array
* Verifying that the `permissions` field remains an array in MongoDB
* Verifying that permission retrieval and synchronization continue to work correctly

Testing environment:

* Laravel
* MongoDB
* mostafamaklad/laravel-permission-mongodb

## Screenshots (if appropriate)

N/A

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [x] I have read the **[[CONTRIBUTING](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md)** document.
* [x] My pull request addresses exactly one patch/feature.
* [x] I have created a branch for this patch/feature.
* [x] Each individual commit in the pull request is meaningful.
* [x] I have added tests to cover my changes.
* [ ] If my change requires a change to the documentation, I have updated it accordingly.